### PR TITLE
docs: set base URL to /ebpf-docs/ in vitepress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
+  base: '/ebpf-docs/',
   title: "eBPF Docs",
   description: "A eBPF Site",
   themeConfig: {


### PR DESCRIPTION
Change the base URL in the vitepress configuration file to '/ebpf-docs/' to ensure proper hosting and navigation of the eBPF documentation site.